### PR TITLE
Update sealedsecret chart to pull image from dockerhub

### DIFF
--- a/instances/sealed-secrets/values.yaml
+++ b/instances/sealed-secrets/values.yaml
@@ -2,7 +2,7 @@ global: {}
 
 sealed-secrets:
   image:
-    repository: quay.io/bitnami/sealed-secrets-controller
+    repository: bitnami/sealed-secrets-controller
     tag: v0.16.0
     pullPolicy: IfNotPresent
     pullSecret: ""


### PR DESCRIPTION
Signed-off-by: hollisc <hollisc@ca.ibm.com>

The reason for the move of the sealedsecet image from quay.io to dockerhub is in this comment: https://github.com/bitnami-labs/sealed-secrets/issues/822#issuecomment-1104116084