### PR TITLE
v1beta1 to v1 fixed the issue on argo in a 4.10 cluster

### DIFF
--- a/instances/ibm-sfg-b2bi-prod-setup/ibm-b2bi-rb.yaml
+++ b/instances/ibm-sfg-b2bi-prod-setup/ibm-b2bi-rb.yaml
@@ -1,5 +1,5 @@
 # (C) Copyright 2019 Syncsort Incorporated. All rights reserved.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:


### PR DESCRIPTION
working with gunu to deploy this - change was needed to deploy the rolebinding component.  not sure why?  maybe specific to 4.10?